### PR TITLE
Update the Caddyfile to work with Caddy v2

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
 get.belt.sh {
-  proxy / localhost:8081
+  reverse_proxy localhost:8081
   header / -Server
 }


### PR DESCRIPTION
When deploying toolshed to a server running Caddy 2 adding the `Caddyfile` for this service failed with:

`run: adapting config using caddyfile: /etc/caddy/vhosts/toolshed.caddy:2: unrecognized directive: proxy`

As per [upgrade documentation](https://caddyserver.com/docs/v2-upgrade#proxy) I have updated the file to match the v2's new format